### PR TITLE
Allow configuration without beginning a frame

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,11 @@ pub fn ui<F: FnOnce(&egui::CtxRef)>(f: F) {
     get_egui().ui(f)
 }
 
+/// Configure egui without beginning or ending a frame.
+pub fn cfg<F: FnOnce(&egui::CtxRef)>(f: F) {
+    f(get_egui().0.egui_ctx());
+}
+
 /// Draw egui ui. Must be called after `ui` and once per frame.
 pub fn draw() {
     get_egui().draw()


### PR DESCRIPTION
Currently, it's not possible to configure the egui context (ie. change fonts) without using `ui` and thus start a frame. This small change allows calling it before the game loop, or even within the loop without beginning a new frame.