### PR TITLE
Bump egui to 0.16.0, egui-miniquad to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-macroquad"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Ilya Sheprut <optozorax@gmail.com>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -18,12 +18,12 @@ include = [
 ]
 
 [dependencies]
-egui = "0.15.0"
-egui-miniquad = "0.7.0"
+egui = "0.16.0"
+egui-miniquad = "0.8.0"
 macroquad = "0.3.6"
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.15.0", default-features = false }
+egui_demo_lib = { version = "0.16.0", default-features = false }
 
 [profile.release]
 opt-level = 2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,9 +78,7 @@ impl Egui {
         let gl = unsafe { get_internal_gl() };
         macroquad::input::utils::repeat_all_miniquad_input(self, self.1);
 
-        self.0.begin_frame(gl.quad_context);
-        f(self.0.egui_ctx());
-        self.0.end_frame(gl.quad_context);
+        self.0.run(gl.quad_context, f);
     }
 
     fn draw(&mut self) {


### PR DESCRIPTION
Egui 0.16.0 was released, which replaced `begin_frame` and `end_frame` with `run`: https://github.com/emilk/egui/blob/master/CHANGELOG.md