### PR TITLE
Fix miniquad scaling compatibility

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -20,6 +20,8 @@ async fn main() {
     let mut egui_demo_windows = egui_demo_lib::DemoWindows::default();
     let mut draw_primitives_after_egui = false;
 
+    let mut pixels_per_point = 1.0;
+
     loop {
         clear_background(WHITE);
 
@@ -34,7 +36,16 @@ async fn main() {
                     &mut draw_primitives_after_egui,
                     "Draw macroquad primitives after egui",
                 );
+
+                ui.add(
+                    egui::Slider::new(&mut pixels_per_point, 0.75..=3.0).logarithmic(true)
+                );
             });
+
+            // Don't change scale while dragging the slider
+            if !egui_ctx.is_using_pointer() {
+                egui_ctx.set_pixels_per_point(pixels_per_point);
+            }
         });
 
         set_camera(&Camera2D {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,11 +99,6 @@ pub fn cfg<F: FnOnce(&egui::Context)>(f: F) {
     f(get_egui().0.egui_ctx());
 }
 
-/// Configure egui miniquad.
-pub fn egui_mq_cfg<F: FnOnce(&'static mut EguiMq)>(f: F) {
-    f(&mut get_egui().0);
-}
-
 /// Draw egui ui. Must be called after `ui` and once per frame.
 pub fn draw() {
     get_egui().draw()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ impl Egui {
         )
     }
 
-    fn ui<F: FnOnce(&egui::Context)>(&mut self, f: F) {
+    fn ui<F: FnOnce(&mut mq::Context, &egui::Context)>(&mut self, f: F) {
         let gl = unsafe { get_internal_gl() };
         macroquad::input::utils::repeat_all_miniquad_input(self, self.1);
 
@@ -91,7 +91,7 @@ impl Egui {
 
 /// Calculates egui ui. Must be called once per frame.
 pub fn ui<F: FnOnce(&egui::Context)>(f: F) {
-    get_egui().ui(f)
+    get_egui().ui(|_, ctx| f(ctx))
 }
 
 /// Configure egui without beginning or ending a frame.
@@ -114,12 +114,12 @@ impl mq::EventHandler for Egui {
 
     fn draw(&mut self, _ctx: &mut mq::Context) {}
 
-    fn mouse_motion_event(&mut self, ctx: &mut mq::Context, x: f32, y: f32) {
-        self.0.mouse_motion_event(ctx, x, y);
+    fn mouse_motion_event(&mut self, _ctx: &mut mq::Context, x: f32, y: f32) {
+        self.0.mouse_motion_event(x, y);
     }
 
-    fn mouse_wheel_event(&mut self, ctx: &mut mq::Context, dx: f32, dy: f32) {
-        self.0.mouse_wheel_event(ctx, dx, dy);
+    fn mouse_wheel_event(&mut self, _ctx: &mut mq::Context, dx: f32, dy: f32) {
+        self.0.mouse_wheel_event(dx, dy);
     }
 
     fn mouse_button_down_event(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,11 @@ pub fn cfg<F: FnOnce(&egui::Context)>(f: F) {
     f(get_egui().0.egui_ctx());
 }
 
+/// Configure egui miniquad.
+pub fn egui_mq_cfg<F: FnOnce(&'static mut EguiMq)>(f: F) {
+    f(&mut get_egui().0);
+}
+
 /// Draw egui ui. Must be called after `ui` and once per frame.
 pub fn draw() {
     get_egui().draw()


### PR DESCRIPTION
It seems `egui-macroquad` is not currently compatible with the latest `egui-miniquad` after https://github.com/not-fl3/egui-miniquad/pull/40 was merged. ~~I'm basing this off of https://github.com/optozorax/egui-macroquad/pull/20 as that seems to be related to the original macroquad issue.~~

~~I'm not entirely sure if that is required, but the PR doesn't compile with miniquad after the fix.~~

This PR makes `egui-macroquad` work with latest `egui-miniquad` again, and based on my quick testing it seems UI scaling works with these changes.

~~Maybe a question for @buxx or @emilk, does the `egui_mq_cfg` still make sense after those changes?~~

~~I'm also not sure if `mq::Context` should be exposed up via `egui_macroquad::ui(...)`, but since this causes existing code to fail to compile I thought it probably shouldn't? It's not a big change, but I don't know the reason why it was added in the first place, so it's hard for me to judge if it should be ignored at the level of `egui-macroquad` or passed up as a breaking change.~~

edit: Removed the `egui_mq_cfg` from #20 since it's not needed anymore