### PR TITLE
update egui and egui-miniquad versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,12 @@ include = [
 ]
 
 [dependencies]
-egui = "0.18.0"
-egui-miniquad = "0.11.0"
+egui = "0.19.0"
+egui-miniquad = "0.12.0"
 macroquad = { version = "0.3.16", default-features = false }
 
 [dev-dependencies]
-egui_demo_lib = { version = "0.18.0", default-features = false }
+egui_demo_lib = { version = "0.19.0", default-features = false }
 
 [profile.release]
 opt-level = 2


### PR DESCRIPTION
Hello,

Unable to run demo with current `master` :

```
➜  egui-macroquad git:(master) ✗ cargo run --example demo         
   Compiling egui-macroquad v0.11.0 (/home/bastiensevajol/Projets/egui-macroquad)
error[E0277]: expected a `FnOnce<(&egui::Context,)>` closure, found `F`
   --> src/lib.rs:81:37
    |
81  |         self.0.run(gl.quad_context, f);
    |                ---                  ^ expected an `FnOnce<(&egui::Context,)>` closure, found `F`
    |                |
    |                required by a bound introduced by this call
    |
    = note: expected a closure taking 2 arguments, but one taking 1 argument was given
note: required by a bound in `EguiMq::run`
   --> /home/bastiensevajol/.cargo/registry/src/github.com-1ecc6299db9ec823/egui-miniquad-0.11.0/src/lib.rs:145:66
    |
145 |     pub fn run(&mut self, mq_ctx: &mut mq::Context, run_ui: impl FnOnce(&egui::Context)) {
    |                                                                  ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `EguiMq::run`

error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> src/lib.rs:113:16
    |
113 |         self.0.mouse_motion_event(x, y);
    |                ^^^^^^^^^^^^^^^^^^ -  - supplied 2 arguments
    |                |
    |                expected 3 arguments
    |
note: associated function defined here
   --> /home/bastiensevajol/.cargo/registry/src/github.com-1ecc6299db9ec823/egui-miniquad-0.11.0/src/lib.rs:204:12
    |
204 |     pub fn mouse_motion_event(&mut self, ctx: &mut mq::Context, x: f32, y: f32) {
    |            ^^^^^^^^^^^^^^^^^^

error[E0061]: this function takes 3 arguments but 2 arguments were supplied
   --> src/lib.rs:117:16
    |
117 |         self.0.mouse_wheel_event(dx, dy);
    |                ^^^^^^^^^^^^^^^^^ --  -- supplied 2 arguments
    |                |
    |                expected 3 arguments
    |
note: associated function defined here
   --> /home/bastiensevajol/.cargo/registry/src/github.com-1ecc6299db9ec823/egui-miniquad-0.11.0/src/lib.rs:210:12
    |
210 |     pub fn mouse_wheel_event(&mut self, _ctx: &mut mq::Context, dx: f32, dy: f32) {
    |            ^^^^^^^^^^^^^^^^^

Some errors have detailed explanations: E0061, E0277.
For more information about an error, try `rustc --explain E0061`.
error: could not compile `egui-macroquad` due to 3 previous errors
```

Update egui and egui-miniquad dependencies solved most of the problems (see MR). But now I got : 

```
➜  egui-macroquad git:(follow-dependencies) ✗ cargo run --example demo        
   Compiling egui-macroquad v0.11.0 (/home/bastiensevajol/Projets/egui-macroquad)
error[E0308]: mismatched types
  --> examples/demo.rs:30:38
   |
30 |                 egui_demo_windows.ui(egui_ctx);
   |                                      ^^^^^^^^ expected struct `egui::context::Context`, found struct `egui::Context`
   |
   = note: expected reference `&egui::context::Context`
              found reference `&egui::Context`
   = note: perhaps two different versions of crate `egui` are being used?

For more information about this error, try `rustc --explain E0308`.
error: could not compile `egui-macroquad` due to previous error
```

Not sure to understand what to do :thinking: 