### PR TITLE
Window recreation fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,6 +104,14 @@ pub fn draw() {
     get_egui().draw()
 }
 
+// Intended to be used only if you recreate the window, making the old EGUI instance invalid.
+#[doc(hidden)]
+pub fn reset_egui() {
+    unsafe {
+        EGUI = None;
+    }
+}
+
 impl mq::EventHandler for Egui {
     fn update(&mut self, _ctx: &mut mq::Context) {}
 


### PR DESCRIPTION
If you use `Window` directly and create a window multiple times in the same application (and use `egui_macroquad` in the first window), the EGUI state gets invalid, so this adds a way to reset the state so you can use `egui_macroquad` again after recreating the window.