### PR TITLE
Upgrade to egui v0.25 and macroquad v0.4.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 homepage = "https://github.com/optozorax/egui-macroquad"
 repository = "https://github.com/optozorax/egui-macroquad"
 description = "Bindings between egui and macroquad"
-readme="README.md"
+readme = "README.md"
 categories = ["gui", "game-development"]
 keywords = ["gui", "imgui", "immediate", "portable", "gamedev"]
 include = [
@@ -18,16 +18,17 @@ include = [
 ]
 
 [dependencies]
-egui = "0.21.0"
-egui-miniquad = "0.14.0"
-macroquad = { version="0.3.25", default-features=false }
+egui = "0.25.0"
+# a fork of egui-miniquad that's been updated to support 0.25.0
+egui-miniquad = { git = 'https://github.com/caspark/egui-miniquad.git', rev="fc2115bd737096df83f7f64c29cb6b5b243bb30c" }
+macroquad = { version="0.4.4", default-features=false }
 
 [features]
 default = ["audio"]
 audio = ["macroquad/audio"]
 
 [dev-dependencies]
-egui_demo_lib = "0.21.0"
+egui_demo_lib = "0.25.0"
 
 [profile.release]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ include = [
 
 [dependencies]
 egui = "0.25.0"
-# a fork of egui-miniquad that's been updated to support 0.25.0
-egui-miniquad = { git = 'https://github.com/caspark/egui-miniquad.git', rev="fc2115bd737096df83f7f64c29cb6b5b243bb30c" }
+# use a fork of egui-miniquad that's been updated to support egui 0.25.0 until https://github.com/not-fl3/egui-miniquad/pull/65 is merged
+egui-miniquad = { git = 'https://github.com/caspark/egui-miniquad.git', rev="4fb6d4c4f3c1ed2114c5cf80f8ce967f5301e318" }
 macroquad = { version="0.4.4", default-features=false }
 
 [features]


### PR DESCRIPTION
This PR upgrades to egui v0.25 and updates macroquad to v0.4.4, which brings both dependencies up to date.

(And also makes a minor stylistic change: rewriting `struct Egui(EguiMq, usize)` as `struct Egui { egui_mq: EguiMq, input_subscriber_id: usize }`, because initially I was wondering what that usize was for, so now next time I look at this code I won't have to wonder. If you don't like this, feel free to undo it.)

It currently depends on my fork of egui-miniquad, which itself has been patched to upgrade egui to 0.25.0. I've raised https://github.com/not-fl3/egui-miniquad/pull/65 to get these changes integrated into egui-miniquad proper, but I don't know when/if that'll get merged so here I've left a reference to my egui-miniquad fork in the Cargo.toml.

To be honest, I don't expect you to merge this PR until (unless?) my egui-miniquad PR is merged - but having this PR open will at least allow others to see that there is a fork which has the latest egui, which might save someone doing the same work I just did. Folks who don't want to wait can reference my fork directly in their Cargo.toml:

```toml
egui-macroquad = { git = 'https://github.com/caspark/egui-macroquad.git', rev = "727670e220fe1d2ce0e6f9f1ba903b4a3a71daca" }
```