### PR TITLE
Allow users to enable log-rs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ macroquad = { version="0.4.4", default-features=false }
 [features]
 default = ["audio"]
 audio = ["macroquad/audio"]
+logs-rs = ["macroquad/log-rs"]
 
 [dev-dependencies]
 egui_demo_lib = "0.25.0"


### PR DESCRIPTION
We shouldn't hide macroquad features as this is just a wrapper
