### PR TITLE
Upgrade to egui 0.27 and use egui_miniquad master git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-egui = "0.27.2"
+egui = "0.27.0"
 egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', rev="5df57233a60f75faadfa14a3ad9d4cddde637605" }
 macroquad = { version="0.4.4", default-features=false }
 
@@ -28,7 +28,7 @@ default = ["audio"]
 audio = ["macroquad/audio"]
 
 [dev-dependencies]
-egui_demo_lib = "0.27.2"
+egui_demo_lib = "0.27.0"
 
 [profile.release]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ include = [
 ]
 
 [dependencies]
-egui = "0.28.1"
+egui = "0.29.0"
 egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', branch="master" }
 macroquad = { version="0.4.5", default-features=false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 
 [dependencies]
 egui = "0.28.1"
-egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', rev="5df57233a60f75faadfa14a3ad9d4cddde637605" }
+egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', branch="master" }
 macroquad = { version="0.4.5", default-features=false }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ include = [
 ]
 
 [dependencies]
-egui = "0.27.0"
-# use a fork of egui-miniquad that's been updated to support egui 0.25.0 until https://github.com/not-fl3/egui-miniquad/pull/65 is merged
+egui = "0.27.2"
 egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', branch="master" }
 macroquad = { version="0.4.4", default-features=false }
 
@@ -29,7 +28,7 @@ default = ["audio"]
 audio = ["macroquad/audio"]
 
 [dev-dependencies]
-egui_demo_lib = "0.27.0"
+egui_demo_lib = "0.27.2"
 
 [profile.release]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ include = [
 ]
 
 [dependencies]
-egui = "0.27.0"
+egui = "0.28.1"
 egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', rev="5df57233a60f75faadfa14a3ad9d4cddde637605" }
-macroquad = { version="0.4.4", default-features=false }
+macroquad = { version="0.4.5", default-features=false }
 
 
 [features]
@@ -28,7 +28,7 @@ default = ["audio"]
 audio = ["macroquad/audio"]
 
 [dev-dependencies]
-egui_demo_lib = "0.27.0"
+egui_demo_lib = "0.28.1"
 
 [profile.release]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default = ["audio"]
 audio = ["macroquad/audio"]
 
 [dev-dependencies]
-egui_demo_lib = "0.28.1"
+egui_demo_lib = "0.29.0"
 
 [profile.release]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-macroquad"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Ilya Sheprut <optozorax@gmail.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -18,17 +18,18 @@ include = [
 ]
 
 [dependencies]
-egui = "0.25.0"
+egui = "0.27.0"
 # use a fork of egui-miniquad that's been updated to support egui 0.25.0 until https://github.com/not-fl3/egui-miniquad/pull/65 is merged
-egui-miniquad = { git = 'https://github.com/caspark/egui-miniquad.git', rev="4fb6d4c4f3c1ed2114c5cf80f8ce967f5301e318" }
+egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', branch="master" }
 macroquad = { version="0.4.4", default-features=false }
+
 
 [features]
 default = ["audio"]
 audio = ["macroquad/audio"]
 
 [dev-dependencies]
-egui_demo_lib = "0.25.0"
+egui_demo_lib = "0.27.0"
 
 [profile.release]
 opt-level = 2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ include = [
 
 [dependencies]
 egui = "0.27.2"
-egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', branch="master" }
+egui-miniquad = { git = 'https://github.com/not-fl3/egui-miniquad.git', rev="5df57233a60f75faadfa14a3ad9d4cddde637605" }
 macroquad = { version="0.4.4", default-features=false }
 
 


### PR DESCRIPTION
This pull request makes it so that the demo example compiles again and upgrades the egui version to match the one used in the latest egui_miniquad