### PR TITLE
Update to egui 0.31.1 and egui-miniquad 0.16.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,6 @@ egui_demo_lib = "0.31.1"
 
 [profile.release]
 opt-level = 2
+
+[lints.rust]
+static_mut_refs = { level = "allow" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui-macroquad"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["Ilya Sheprut <optozorax@gmail.com>"]
 edition = "2021"
 license = "MIT/Apache-2.0"
@@ -18,17 +18,16 @@ include = [
 ]
 
 [dependencies]
-egui = "0.25.0"
-# use a fork of egui-miniquad that's been updated to support egui 0.25.0 until https://github.com/not-fl3/egui-miniquad/pull/65 is merged
-egui-miniquad = { git = 'https://github.com/caspark/egui-miniquad.git', rev="4fb6d4c4f3c1ed2114c5cf80f8ce967f5301e318" }
-macroquad = { version="0.4.4", default-features=false }
+egui = "0.31.1"
+egui-miniquad = "0.16.0"
+macroquad = { version="0.4.14", default-features=false }
 
 [features]
 default = ["audio"]
 audio = ["macroquad/audio"]
 
 [dev-dependencies]
-egui_demo_lib = "0.25.0"
+egui_demo_lib = "0.31.1"
 
 [profile.release]
 opt-level = 2

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -47,7 +47,7 @@ async fn main() {
                 );
 
                 // Don't change scale while dragging the slider
-                if response.drag_released() {
+                if response.drag_stopped() {
                     egui_ctx.set_pixels_per_point(pixels_per_point.unwrap());
                 }
             });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ impl Egui {
 
     fn ui<F>(&mut self, f: F)
     where
-        F: FnOnce(&mut dyn mq::RenderingBackend, &egui::Context),
+        F: FnMut(&mut dyn mq::RenderingBackend, &egui::Context),
     {
         let gl = unsafe { get_internal_gl() };
         macroquad::input::utils::repeat_all_miniquad_input(self, self.input_subscriber_id);
@@ -96,7 +96,7 @@ impl Egui {
 }
 
 /// Calculates egui ui. Must be called once per frame.
-pub fn ui<F: FnOnce(&egui::Context)>(f: F) {
+pub fn ui<F: FnMut(&egui::Context)>(mut f: F) {
     get_egui().ui(|_, ctx| f(ctx))
 }
 


### PR DESCRIPTION
Hi all,

## Changes

- Move back to using upstream `egui-miniquad`
- Update `egui-miniquad` to `0.16.0`
- Update `egui` to `0.31.1`
- Update `macroquad` to `0.4.14`
- Bump the `egui-macroquad` version to `0.17.0` for release
- Switch `FnOnce` to `FnMut` where now required
- Switch deprecated `drag_released()` to new `drag_stopped()`
- Turn of lint warnings for references to `static mut`'s (these are common practice within macroquad itself, and are accepted since the engine itself is single threaded)

@optozorax This should take care of everything for a new release to be pushed to crates.io.